### PR TITLE
Reduce minishift Kafka replicas to 1

### DIFF
--- a/src/main/paradox/includes/deploying-kafka.md
+++ b/src/main/paradox/includes/deploying-kafka.md
@@ -71,7 +71,7 @@ metadata:
   name: strimzi
 spec:
   kafka:
-    replicas: 3
+    replicas: 1
     listeners:
       plain: {}
       tls: {}


### PR DESCRIPTION
I gathered from the surrounding text that this was the intent, and assume that leaving it at 3 was a copy/paste mistake.