### PR TITLE
Increase navigation depth to 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,3 +34,4 @@ Compile / unmanagedSourceDirectories ++= ((Compile / paradox / sourceDirectory).
   ParadoxPlugin.InDirectoryFilter((Compile / paradox / sourceDirectory).value / "includes")
 
 paradoxTheme := Some(builtinParadoxTheme("generic"))
+paradoxNavigationDepth := 3


### PR DESCRIPTION
Previously, some pages didn't appear in the left side navigation.

This is one possible solution. Another might be to un-nest those pages.