### PR TITLE
Add missing permission to schema creation script

### DIFF
--- a/src/main/paradox/includes/deploying-postgres.md
+++ b/src/main/paradox/includes/deploying-postgres.md
@@ -91,6 +91,7 @@ GRANT CONNECT ON DATABASE $database.user$ TO $database.name$;
 
 \connect $database.name$;
 REVOKE ALL ON SCHEMA public FROM PUBLIC;
+GRANT USAGE ON SCHEMA public TO $database.user$;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO $database.user$;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public


### PR DESCRIPTION
This was necessary for me to be able to access the schema from the `shopping_cart` user.

I did muck around a lot with different permissions in the process of trying to work this out, so I'd like to try again from scratch before merging.