### PR TITLE
WIP - Split config and spec into smaller pieces and interleaves them

### DIFF
--- a/src/main/paradox/lagom/forming-a-cluster.md
+++ b/src/main/paradox/lagom/forming-a-cluster.md
@@ -2,6 +2,8 @@
 
 If you're using any of the Akka cluster based features of Lagom, such as Lagom Persistence, or Lagom Pub Sub, you will need to configure your Lagom services to form a cluster. Akka clusters are groups of nodes, usually running the same code base, that distribute their state and work across them. For example, Lagom persistent entities are distributed across an Akka cluster ensuring that each entity only resides on one node at a time, ensuring that strongly consistent operations can be done on that entity without any need of coordination, such as transactions, between nodes.
 
+
+
 ## Bootstrap process
 
 @@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #bootstrap-process }
@@ -10,6 +12,22 @@ If you're using any of the Akka cluster based features of Lagom, such as Lagom P
 @@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #bootstrap-deps }
 
 @@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-akka-cluster }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-akka-management-http }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #deployment-spec-management-port }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #deployment-spec-health-checks }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-akka-cluster-bootstrap }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #deployment-spec-replicas }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #deployment-spec-rbac }
+
+
 
 ## Starting
 
@@ -31,4 +49,4 @@ And now bind that in `com.example.shoppingcart.impl.ShoppingCartModule`:
 
 @@snip [ShoppingCartModule.java](code/jdocs/lagom/FormingACluster.java) { #start }
 
-@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #deployment-spec }
+


### PR DESCRIPTION
This PR splits the Config includes and the spec includes into smaller pieces so that a certain config is documented immediately next to the changes in Spec. This makes it easier to understand what is the absolute set of changes when adding bootstrap or health checks or...


I still find the resulting page too long. On top of that, all the bits use `H3` headings so the current page is still not super clear to read.

I'm sharing this idea early to iterate. IDK, maybe each bit should be more clearly separate or even a small, specific page (instead of a big page with several includes).

 - - - - - - 
Screenshot - Before / After

<img width="500" alt="screen shot 2019-03-05 at 18 25 32" src="https://user-images.githubusercontent.com/762126/53825372-7699ea00-3f76-11e9-8ea0-8e330ddd2a40.png">
