### PR TITLE
Fix rendering of cluster bootstrap dependencies

### DIFF
--- a/src/main/paradox/includes/forming-a-cluster.md
+++ b/src/main/paradox/includes/forming-a-cluster.md
@@ -18,7 +18,6 @@ To use Akka cluster bootstrap, you'll need to add the following dependencies to 
 
 sbt
 :    @@@vars
-
 ```scala
 libraryDependencies ++= Seq(
   "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "$akka.management.version$",
@@ -30,7 +29,6 @@ libraryDependencies ++= Seq(
 
 Maven
 :    @@@vars
-
 ```xml
 <dependency>
   <groupId>com.lightbend.akka.management</groupId>


### PR DESCRIPTION
Paradox is sensitive to extra newlines here.

Before:

<img width="353" alt="Screen Shot 2019-03-19 at 5 14 28 pm" src="https://user-images.githubusercontent.com/44385/54585623-82070e00-4a6a-11e9-9b6d-9f5b71cc63c6.png">

After:

<img width="610" alt="Screen Shot 2019-03-19 at 5 15 07 pm" src="https://user-images.githubusercontent.com/44385/54585645-90552a00-4a6a-11e9-9f92-797fac906b53.png">
