### PR TITLE
Adapt for Lagom 1.5.0 deployment

### DIFF
--- a/src/main/paradox/includes/forming-a-cluster.md
+++ b/src/main/paradox/includes/forming-a-cluster.md
@@ -82,7 +82,7 @@ akka {
 <!--- #configuring-akka-mngt-config -->
 ### Akka management HTTP
 
-Akka management HTTP provides an HTTP API for querying the status of the Akka cluster, used both by the bootstrap process, as well as healthchecks to ensure requests don't get routed to your pods until the pods have joined the cluster.
+Akka management HTTP provides an HTTP API for querying the status of the Akka cluster, used both by the bootstrap process, as well as @ref:[health checks](#health-checks) to ensure requests don't get routed to your pods until the pods have joined the cluster.
 
 The default configuration for Akka management HTTP is suitable for use in Kubernetes, it will bind to a default port of 8558 on the pods external IP address.
 <!--- #configuring-akka-mngt-config -->

--- a/src/main/paradox/includes/forming-a-cluster.md
+++ b/src/main/paradox/includes/forming-a-cluster.md
@@ -68,7 +68,7 @@ akka {
 
     cluster {
         # after 60s of unsuccessul attempts to form a cluster, 
-        # the actor system will be terminated
+        # the actor system will shut down
         shutdown-after-unsuccessful-join-seed-nodes = 60s
     }
     # exit jvm on actor system termination

--- a/src/main/paradox/includes/forming-a-cluster.md
+++ b/src/main/paradox/includes/forming-a-cluster.md
@@ -58,8 +58,8 @@ There are three components that need to be configured for cluster bootstrap to w
 <!--- #configuring-general-config -->
 ### Akka Cluster
 
-The first thing that's needed is a general Akka cluster configuration. For the most part, we'll rely on the defaults, for example, the default port that Akka remoting binds to is 2552. But there are a few things we need to tweak. We need to first enable Akka cluster by making it the Actor provider. We also want to tell Akka to shut itself down if it's unable to join the cluster after a given timeout. This is very important, as we will see further down, we will use the cluster formation status to decide when the service is ready to receive traffic by means of configuring a readiness health check probe. Kubernetes won't restart an application based on the readiness probe, therefore, if for some reason we fail to form a cluster we must have the means to stop the pod and let Kubernetes re-create it.
-
+The first thing that's needed is a general Akka cluster configuration. For the most part, we'll rely on the defaults, for example, the default port that Akka remoting binds to is 2552. But there are a few things we need to tweak. We need to first enable Akka cluster by making it the Actor provider. We also want to tell Akka to shut itself down if it's unable to join the cluster after a given timeout and we need to tell Akka to exit the JVM when that happens. This is very important, as we will see further down, we will use the cluster formation status to decide when the service is ready to receive traffic by means of configuring a readiness health check probe. Kubernetes won't restart an application based on the readiness probe, therefore, if for some reason we fail to form a cluster we must have the means to stop the pod and let Kubernetes re-create it.
+Setup](setup/index.md)
 ```HOCON
 akka {
     actor {
@@ -70,9 +70,10 @@ akka {
         # after 60s of unsuccessul attempts to form a cluster, 
         # the actor system will be terminated
         shutdown-after-unsuccessful-join-seed-nodes = 60s
-        # exit jvm on actor system termination
-        akka.coordinated-shutdown.exit-jvm = on
     }
+    # exit jvm on actor system termination
+    # this will allow Kubernetes to restart the pod
+    coordinated-shutdown.exit-jvm = on
 }
 ```
 <!--- #configuring-general-config -->

--- a/src/main/paradox/lagom/forming-a-cluster.md
+++ b/src/main/paradox/lagom/forming-a-cluster.md
@@ -12,7 +12,7 @@ These components are automatically added by Lagom whenever Lagom Persistence or 
 
 ### Akka Cluster
 
-Most of the Akka cluster configuration is already handled by Lagom. There are two things we need to configure, we need to tell Akka to shut itself down if it's unable to join the cluster after a given timeout and we need to tell Lagom to exit the JVM when that happens. This is very important, as we will see further down, we will use the cluster formation status to decide when the service is ready to receive traffic by means of configuring a readiness health check probe. Kubernetes won't restart an application based on the readiness probe, therefore, if for some reason we fail to form a cluster we must have the means to stop the pod and let Kubernetes re-create it.
+Most of the Akka cluster configuration is already handled by Lagom. There are two things we need to configure, we need to tell Akka to shut itself down if it's unable to join the cluster after a given timeout and we need to tell Lagom to exit the JVM when that happens. This is very important, @ref:[as we will see further down](#health-checks), we will use the cluster formation status to decide when the service is ready to receive traffic by means of configuring a readiness health check probe. Kubernetes won't restart an application based on the readiness probe, therefore, if for some reason we fail to form a cluster we must have the means to stop the pod and let Kubernetes re-create it.
 
 ```HOCON
 # after 60s of unsuccessul attempts to form a cluster, 
@@ -28,10 +28,12 @@ lagom.cluster.exit-jvm-when-system-terminated = on
 
 This component is already included and configured by Lagom. 
 
-@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-health-check-config }
-
-Lagom also includes the routes for `akka-management-cluster-http`, meaning that the readiness check will take the cluster membership status into consideration.
-
 @@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-cluster-bootsrap-config }
 
 @@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #deployment-spec }
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-health-check }
+
+Lagom also includes the routes for `akka-management-cluster-http`, meaning that the readiness check will take the cluster membership status into consideration.
+
+@@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-health-check-spec }

--- a/src/main/paradox/lagom/forming-a-cluster.md
+++ b/src/main/paradox/lagom/forming-a-cluster.md
@@ -12,12 +12,16 @@ These components are automatically added by Lagom whenever Lagom Persistence or 
 
 ### Akka Cluster
 
-Most of the Akka cluster configuration is already handled by Lagom. There is one thing we need to configure which is the timeout for the cluster formation. We want to tell Akka to shut itself down if it's unable to join the cluster after a given timeout. This is very important, as we will see further down, we will use the cluster formation status to decide when the service is ready to receive traffic by means of configuring a readiness health check probe. Kubernetes won't restart an application based on the readiness probe, therefore, if for some reason we fail to form a cluster we must have the means to stop the pod and let Kubernetes re-create it.
+Most of the Akka cluster configuration is already handled by Lagom. There are two things we need to configure, we need to tell Akka to shut itself down if it's unable to join the cluster after a given timeout and we need to tell Lagom to exit the JVM when that happens. This is very important, as we will see further down, we will use the cluster formation status to decide when the service is ready to receive traffic by means of configuring a readiness health check probe. Kubernetes won't restart an application based on the readiness probe, therefore, if for some reason we fail to form a cluster we must have the means to stop the pod and let Kubernetes re-create it.
 
 ```HOCON
 # after 60s of unsuccessul attempts to form a cluster, 
-# the actor system will be terminated causing the shutdown of the Lagom service
+# the actor system will be terminated
 akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 60s
+
+# exit jvm on actor system termination
+# this will allow Kubernetes to restart the pod
+lagom.cluster.exit-jvm-when-system-terminated = on
 ```
 
 @@include[forming-a-cluster.md](../includes/forming-a-cluster.md) { #configuring-akka-mngt-config }

--- a/src/main/paradox/lagom/forming-a-cluster.md
+++ b/src/main/paradox/lagom/forming-a-cluster.md
@@ -16,7 +16,7 @@ Most of the Akka cluster configuration is already handled by Lagom. There are tw
 
 ```HOCON
 # after 60s of unsuccessul attempts to form a cluster, 
-# the actor system will be terminated
+# the actor system will shut down
 akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 60s
 
 # exit jvm on actor system termination

--- a/src/main/paradox/lagom/index.md
+++ b/src/main/paradox/lagom/index.md
@@ -1,6 +1,6 @@
 # Deploying a Lagom application to OpenShift
 
-For this guide we will be using the Lagom shopping cart sample application. It is available for both Java and Scala, and uses a PostgreSQL database. It covers how to deploy a Lagom 1.5.0 application.
+For this guide we will be using the Lagom shopping cart sample application. It is available for both [Java](https://github.com/lagom/shopping-cart-java/tree/1.5.x) and [Scala](https://github.com/lagom/shopping-cart-scala/tree/1.5.x), and uses a PostgreSQL database. This guide covers how to deploy a Lagom 1.5.0 application.
 
 This sample application just offers a REST API, it does not off a user interface, so we will interact with it using `curl`. It comprises two services - a shopping cart service, that manages shopping carts, and an inventory service, that tracks inventory levels. The shopping cart service communicates with the inventory service using Kafka, when a user completes the purchase, a message is sent from the shopping cart service to the inventory service.
 

--- a/src/main/paradox/lagom/index.md
+++ b/src/main/paradox/lagom/index.md
@@ -1,8 +1,8 @@
 # Deploying a Lagom application to OpenShift
 
-For this guide we will be using the Lagom shopping cart sample application. It is available for both Java and Scala, and uses a PostgreSQL database.
+For this guide we will be using the Lagom shopping cart sample application. It is available for both Java and Scala, and uses a PostgreSQL database. It covers how to deploy a Lagom 1.5.0 application.
 
-This sample application just offers a REST API, it does not off a user interface, so we will interact with it using curl. It comprises two services - a shopping cart service, that manages shopping carts, and an inventory service, that tracks inventory levels. The shopping cart service communicates with the inventory service using Kafka, when a user completes the purchase, a message is sent from the shopping cart service to the inventory service.
+This sample application just offers a REST API, it does not off a user interface, so we will interact with it using `curl`. It comprises two services - a shopping cart service, that manages shopping carts, and an inventory service, that tracks inventory levels. The shopping cart service communicates with the inventory service using Kafka, when a user completes the purchase, a message is sent from the shopping cart service to the inventory service.
 
 The shopping cart sample application can be cloned from the following GitHub repositories:
 


### PR DESCRIPTION
This is the PR to adapt the guide for Lagom 1.5.0. I few things to notice:

* I explicitly left Lagom 1.4.0 out although we said that it could be a good idea to keep it (more on this further down)
* we don't have it the guide for akka, but I understand that some work was already done to reuse some content. I tried to keep the same approach and only copy-n-paste text when it was really necessary to add some Lagom specifics (or remove things)
* I remove some text that just because I found it hard to reconcile with some new sentences. For instance, the Lagom part won't have the sentence: "For the most part, we'll rely on the defaults, for example, the default port that Akka remoting binds to is 2552. ". This is because, I found it more useful to tell the users that most of the configuration is already handled by Lagom and that they should not worry about it.

### About Lagom 1.4.0

I explicitly left 1.4.0 out because I have the impression that it will only add confusion to the guide. It's better to have a straight guide dedicated to 1.5.0 instead of here and there a note like, "but if you are using 1.4.0, you need that extra bit". 

On top of that, I also don't think that we want to maintain two other branches of the samples "scala/1.4.x" and "java/1.4.x". That's already too much for us.

Instead, I would like to suggest the following:

* let's keep 1.4.0 out for the moment
* if we decide to re-add it, let's add an "Appendix C: Deploying Lagom 1.4.x" that will only explain the necessary bits to enable Akka Management and Cluster Bootstrap in Lagom 1.4.x. Once that in place, the rest of the guide should be valid for both versions.
* let's not maintain samples for 1.4.x. If someone needs to do the same in Lagom 1.4.x, they can get inspiration from the 1.5.x branch and the above mention appendix.