### PR TITLE
Add --batch-mode to Maven configuration

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--batch-mode


### PR DESCRIPTION
This sets this command line flag by default, greatly reducing the amount
of output in a CI build.

See https://maven.apache.org/configure.html