### PR TITLE
Use service account role bindings

### DIFF
--- a/src/main/paradox/includes/forming-a-cluster.md
+++ b/src/main/paradox/includes/forming-a-cluster.md
@@ -179,15 +179,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
 subjects:
-- kind: User
-  name: system:serviceaccount:myproject:default
+- kind: ServiceAccount
+  name: default
 roleRef:
   kind: Role
   name: pod-reader
   apiGroup: rbac.authorization.k8s.io
 ```
-
-Note the service account name, `system:serviceaccount:myproject:default`, contains the `myproject` namespace in it. If you are using a different project name, you'll need to update it accordingly.
 
 #### A note on secrets with RBAC
 


### PR DESCRIPTION
Not sure if this is where the guide is being maintained now... but anyway, this change makes the role binding simpler (no crazy long username to understand), and also means the role binding is no longer namespace specific, so doesn't need to be edited to use in a different namespace, since when using `ServiceAccount` subjects, the namespace defaults to whichever namespace the role binding is deployed to.

See https://github.com/akka/akka-management/pull/558.